### PR TITLE
Fix missing getmaxyx on some Linux systems

### DIFF
--- a/ping-multi
+++ b/ping-multi
@@ -139,7 +139,8 @@ sub init_curses() {
 	curs_set(0);
 	halfdelay(1); # makes getch() to block with a timeout
 
-	getmaxyx(stdscr, $scr_max->{'y'}, $scr_max->{'x'});
+	$scr_max->{'y'} =  getmaxy(stdscr);
+	$scr_max->{'x'} =  getmaxx(stdscr);
 }
 
 sub handle_pressed_keys() {


### PR DESCRIPTION
My 1st ever perl coding, hoping it's correct. But on some recent systems I couldn't run ping-multi with the following error;
Curses function 'getmaxyx' is not defined in your Curses library at ./ping-multi line 142.
After some searching I could fix it as proposed.